### PR TITLE
Remove support for SLA integration (required to support macOS 12)

### DIFF
--- a/sign.bash
+++ b/sign.bash
@@ -60,10 +60,10 @@ log " ${ver_major}.${ver_minor}"
 log "Backing up the original DMG"
 cp "${pkg}" "${pkg_base}.orig.dmg"
 
-log "Extract SLA"
-hdiutil unflatten "${pkg}"
-DeRez -only 'LPic' -only 'STR#' -only 'TEXT' "${pkg}" > sla.r
-hdiutil flatten "${pkg}"
+#log "Extract SLA"
+#hdiutil unflatten "${pkg}"
+#DeRez -only 'LPic' -only 'STR#' -only 'TEXT' "${pkg}" > sla.r
+#hdiutil flatten "${pkg}"
 
 log "Convert from original image to uncompressed read-write"
 hdiutil convert "${pkg}" -format UDRW -o "${pkg_base}.rw"
@@ -235,11 +235,11 @@ log "Convert to intermediate format needed for rez tool."
 hdiutil convert "${pkg_base}.rw.dmg" -format UDRO -o "${pkg_base}.ro"
 rm -f "${pkg_base}.rw.dmg"
 
-log "Re-insert SLA with rez tool."
-hdiutil unflatten "${pkg_base}.ro.dmg"
-Rez sla.r -a -o "${pkg_base}.ro.dmg"
-hdiutil flatten "${pkg_base}.ro.dmg"
-rm -f sla.r
+#log "Re-insert SLA with rez tool."
+#hdiutil unflatten "${pkg_base}.ro.dmg"
+#Rez sla.r -a -o "${pkg_base}.ro.dmg"
+#hdiutil flatten "${pkg_base}.ro.dmg"
+#rm -f sla.r
 
 log "Convert back to read-only, compressed image."
 hdiutil convert "${pkg_base}.ro.dmg" -format UDZO -imagekey zlib-level=9 -ov -o "${pkg}"


### PR DESCRIPTION
Since macOS 12 deprecates the tools needed to attach a SLA, remove the corresponding functionality.

Error reported while signing `SlicerSALT-4.0.1-macosx-amd64.dmg`:

```
hdiutil: unflatten: verb not recognized
Usage: hdiutil <verb> <options>
<verb> is one of the following:
help            	imageinfo
attach          	isencrypted
detach          	makehybrid
eject           	mount
verify          	mountvol
create          	unmount
compact         	plugins
convert         	resize
burn            	segment
info            	pmap
checksum        	udifderez
chpass          	udifrez
erasekeys       	
### DeRez - eofErr (-39) during open of resource file "/Users/jchris.fillionr/tmp/SlicerSALT-4.0.1-macosx-amd64.dmg".
hdiutil: flatten: verb not recognized
Usage: hdiutil <verb> <options>
```

References:
* https://www.apple.com/legal/sla/
* https://gitlab.kitware.com/cmake/cmake/-/issues/20889
* https://gitlab.kitware.com/cmake/cmake/-/commit/2167fce99befa565c3a70d09a2be65a865a2f23a