### PR TITLE
Fix SLA extraction and reinsertion

### DIFF
--- a/sign.bash
+++ b/sign.bash
@@ -88,12 +88,6 @@ readonly lib_subdir
 log "Library subdirectory: ${lib_subdir}"
 
 log "Create temporary directory"
-# Avoid error like the following:
-#
-#  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate:
-#  can't write output file: /Volumes/Slicer-4.10.0-macosx-amd64/Slicer.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/QtWebEngineCore.cstemp (No space left on device)
-#  /Volumes/Slicer-4.10.0-macosx-amd64/Slicer.app: the codesign_allocate helper tool cannot be found or used
-#
 temp_dir=$(mktemp -d)
 readonly temp_dir
 
@@ -106,6 +100,13 @@ readonly tmp_dmg_name
 tmp_app_dir=${tmp_vol_name}/${app_name}
 readonly tmp_app_dir
 
+# Explicitly creating a volume and copying the package files is required
+# to avoid error like the following:
+#
+#  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate:
+#  can't write output file: /Volumes/Slicer-4.10.0-macosx-amd64/Slicer.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/QtWebEngineCore.cstemp (No space left on device)
+#  /Volumes/Slicer-4.10.0-macosx-amd64/Slicer.app: the codesign_allocate helper tool cannot be found or used
+#
 log "Create ${tmp_dmg_name}"
 hdiutil create "${tmp_dmg_name}" -fs HFS+ -size 2g -format UDRW -srcfolder "${temp_dir}"
 

--- a/sign.bash
+++ b/sign.bash
@@ -57,6 +57,21 @@ readonly ver_minor
 
 log " ${ver_major}.${ver_minor}"
 
+for command in \
+  codesign \
+  fsck_hfs \
+  hdiutil \
+  install_name_tool \
+  pkgbuild \
+  plutil \
+  spctl \
+; do
+  if ! command -v "${command}" &> /dev/null; then
+    echo -e >&2 "ERROR: \"${command}\" not found!\n"
+    exit 1
+  fi
+done
+
 log "Backing up the original DMG"
 cp "${pkg}" "${pkg_base}.orig.dmg"
 


### PR DESCRIPTION
Approach for "Extract SLA" and "Re-insert SLA" adapted from https://github.com/Kitware/CMake/commit/bed4b1583 (Utilities/Release: Add script to sign/notarize macOS application bundle)

From https://github.com/Kitware/CMake/commit/1ace60732 (CPack/DragNDrop: Re-implement SLA attachment to avoid deprecated tools):

> The `Rez` tool has been deprecated since Xcode 6.  The `hdiutil flatten` and `hdiutil unflatten` tools have been deprecated since macOS 10.15 and are removed in macOS 11.  Instead use `hdiutil udifrez` to attach the SLA resources to disk images.  This tool accepts XML input files, so convert our resource file generation to produce that format.

This is intended to fix the error like the following (reported while signing `SlicerSALT-4.0.1-macosx-amd64.dmg`):

```
hdiutil: unflatten: verb not recognized
Usage: hdiutil <verb> <options>
<verb> is one of the following:
help            	imageinfo
attach          	isencrypted
detach          	makehybrid
eject           	mount
verify          	mountvol
create          	unmount
compact         	plugins
convert         	resize
burn            	segment
info            	pmap
checksum        	udifderez
chpass          	udifrez
erasekeys       	
### DeRez - eofErr (-39) during open of resource file "/Users/jchris.fillionr/tmp/SlicerSALT-4.0.1-macosx-amd64.dmg".
hdiutil: flatten: verb not recognized
Usage: hdiutil <verb> <options>
```